### PR TITLE
Merge from upstream

### DIFF
--- a/black.py
+++ b/black.py
@@ -3876,8 +3876,8 @@ def diff(a: str, b: str, a_name: str, b_name: str) -> str:
     """Return a unified diff string between strings `a` and `b`."""
     import difflib
 
-    a_lines = [line + "\n" for line in a.split("\n")]
-    b_lines = [line + "\n" for line in b.split("\n")]
+    a_lines = [line + "\n" for line in a.splitlines()]
+    b_lines = [line + "\n" for line in b.splitlines()]
     return "".join(
         difflib.unified_diff(a_lines, b_lines, fromfile=a_name, tofile=b_name, n=5)
     )

--- a/tests/data/blackd_diff.diff
+++ b/tests/data/blackd_diff.diff
@@ -1,6 +1,6 @@
 --- [Deterministic header]
 +++ [Deterministic header]
-@@ -1,7 +1,6 @@
+@@ -1,6 +1,5 @@
 -def abc ():
 -    return ["hello", "world",
 -            "!"]
@@ -9,6 +9,5 @@
  
 -print(   "Incorrect formatting"    
 -)
- 
-+print("Incorrect formatting")
 +
++print("Incorrect formatting")

--- a/tests/data/expression.diff
+++ b/tests/data/expression.diff
@@ -160,7 +160,7 @@
  slice[0:1:2]
  slice[:]
  slice[:-1]
-@@ -134,113 +169,171 @@
+@@ -134,112 +169,170 @@
  numpy[-(c + 1) :, d]
  numpy[:, l[-2]]
  numpy[:, ::-1]
@@ -404,4 +404,3 @@
      return True
  last_call()
  # standalone comment at ENDMARKER
- 


### PR DESCRIPTION
`split("\n")` includes a final empty element `""` if the final line
ends with `\n` (as it should for POSIX-compliant text files), which
then became an extra `"\n"`.

`splitlines()` solves that, but there's a caveat, as it will split
on other types of line breaks too (like `\r`), which may not be
desired.

Fixes #526.