### PR TITLE
Fixing the documentation of how to install the vim plugin (#1318)

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,7 +738,7 @@ Configuration:
 To install with [vim-plug](https://github.com/junegunn/vim-plug):
 
 ```
-Plug 'psf/black'
+Plug 'psf/black', { 'branch': 'stable' }
 ```
 
 or with [Vundle](https://github.com/VundleVim/Vundle.vim):
@@ -747,8 +747,15 @@ or with [Vundle](https://github.com/VundleVim/Vundle.vim):
 Plugin 'psf/black'
 ```
 
+and execute the following in a terminal:
+
+```console
+$ cd ~/.vim/bundle/black
+$ git checkout origin/stable -b stable
+```
+
 or you can copy the plugin from
-[plugin/black.vim](https://github.com/psf/black/tree/master/plugin/black.vim).
+[plugin/black.vim](https://github.com/psf/black/blob/stable/plugin/black.vim).
 
 ```
 mkdir -p ~/.vim/pack/python/start/black/plugin


### PR DESCRIPTION
* fix: Fixing the documentation of how to install the vim plugin

Solves the installation problem that currently exist because
the current master branch is not stable. See psf/black#1304 for
more information.

* fix: fixing incorrect path